### PR TITLE
Add service locator to Hapi server `app` property

### DIFF
--- a/lib/infrastructure/webserver/server.js
+++ b/lib/infrastructure/webserver/server.js
@@ -60,6 +60,8 @@ const createServer = async () => {
     require('../../interfaces/routes/users'),
   ]);
 
+  server.app.serviceLocator = require('../../infrastructure/config/service-locator');
+
   return server;
 };
 

--- a/lib/interfaces/controllers/AuthorizationController.js
+++ b/lib/interfaces/controllers/AuthorizationController.js
@@ -1,13 +1,15 @@
 'use strict';
 
 const Boom = require('@hapi/boom');
-const serviceLocator = require('../../infrastructure/config/service-locator');
 const GetAccessToken = require('../../application/use_cases/GetAccessToken');
 const VerifyAccessToken = require('../../application/use_cases/VerifyAccessToken');
 
 module.exports = {
 
   async getAccessToken(request) {
+
+    // Context
+    const serviceLocator = request.server.app.serviceLocator;
 
     // Input
     const grantType = request.payload['grant_type'];
@@ -30,6 +32,9 @@ module.exports = {
   },
 
   verifyAccessToken(request, h) {
+
+    // Context
+    const serviceLocator = request.server.app.serviceLocator;
 
     // Input
     const authorizationHeader = request.headers.authorization;

--- a/lib/interfaces/controllers/UsersController.js
+++ b/lib/interfaces/controllers/UsersController.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const Boom = require('@hapi/boom');
-const serviceLocator = require('../../infrastructure/config/service-locator');
 const ListUsers = require('../../application/use_cases/ListUsers');
 const CreateUser = require('../../application/use_cases/CreateUser');
 const GetUser = require('../../application/use_cases/GetUser');
@@ -10,6 +9,9 @@ const DeleteUser = require('../../application/use_cases/DeleteUser');
 module.exports = {
 
   async createUser(request) {
+
+    // Context
+    const serviceLocator = request.server.app.serviceLocator;
 
     // Input
     const { firstName, lastName, email, password } = request.payload;
@@ -21,7 +23,10 @@ module.exports = {
     return serviceLocator.userSerializer.serialize(user);
   },
 
-  async findUsers() {
+  async findUsers(request) {
+
+    // Context
+    const serviceLocator = request.server.app.serviceLocator;
 
     // Treatment
     const users = await ListUsers(serviceLocator);
@@ -31,6 +36,9 @@ module.exports = {
   },
 
   async getUser(request) {
+
+    // Context
+    const serviceLocator = request.server.app.serviceLocator;
 
     // Input
     const userId = request.params.id;
@@ -46,6 +54,9 @@ module.exports = {
   },
 
   async deleteUser(request, h) {
+
+    // Context
+    const serviceLocator = request.server.app.serviceLocator;
 
     // Input
     const userId = request.params.id;


### PR DESCRIPTION
There was a problem in flow of control. Service locator is about glue & configuration code. It is why it is located in `infrastructure` folder. Therefore, it was previously directly accessed in controllers, that was wrong.

Close issue #14

See https://hapi.dev/api/?v=19.1.1#-serverapp